### PR TITLE
Import speed improvements

### DIFF
--- a/bin_ops.py
+++ b/bin_ops.py
@@ -24,15 +24,26 @@ fmtSz = {
   'f': 4,
   'd': 8,
   's': 1,
-  'p': 1
-}
+  'p': 1,
+  'C': 1,
+  'B': 1,
+  '?': 1,
+  'H': 2,
+  'I': 4,
+  'L': 4,
+  'Q': 8,
+  'F': 4,
+  'D': 8,
+  'S': 1,
+  'P': 1
+} # lets not run .lower millions of times during map imports
 
 def read(file, fmt):
     size = 0
     for char in fmt:
         if char == '<': continue
-        if char.lower() in fmtSz:
-            size += fmtSz[char.lower()]
+        if char in fmtSz:
+            size += fmtSz[char]
         else:
             print('unrecognized fmt char %s' % (char))
     if size == 0:

--- a/bpyhelper.py
+++ b/bpyhelper.py
@@ -30,10 +30,22 @@ def clean_materials():
 
 LOCK_UPDATE = False
 
+VISIBLE_SELECTION = []
+
 def scene_update():
     if LOCK_UPDATE: return
     bpy.context.view_layer.update()
-def select_obj(object, value): object.select_set(value)
+def select_obj(object, value, track=True):
+     object.select_set(value)
+     if value is True and object.hide_viewport is False and track is True:
+         VISIBLE_SELECTION.append(object)
+
+def deselect_all():
+    global VISIBLE_SELECTION
+    for object in VISIBLE_SELECTION:
+        object.select_set(False)
+    VISIBLE_SELECTION = []
+
 def is_selected(object): return object.select_get()
 def scene_link(object): bpy.context.view_layer.active_layer_collection.collection.objects.link(object)
 def scene_unlink(object): bpy.context.view_layer.active_layer_collection.collection.objects.unlink(object)

--- a/import_owentity.py
+++ b/import_owentity.py
@@ -50,7 +50,7 @@ def read(settings, import_children=False, is_child=False):
 
     if base_model is not None:
         bpy.context.view_layer.objects.active = None
-        bpy.ops.object.select_all(action='DESELECT')
+        bpyhelper.deselect_all()
         import_owmdl.select_all(base_model[0])
         if base_model[1] is not None:
             bpy.context.view_layer.objects.active = base_model[1]

--- a/import_owentity.py
+++ b/import_owentity.py
@@ -55,4 +55,5 @@ def read(settings, import_children=False, is_child=False):
         if base_model[1] is not None:
             bpy.context.view_layer.objects.active = base_model[1]
     
+    bpyhelper.deselect_all()
     return root_object, data, base_model

--- a/import_owmap.py
+++ b/import_owmap.py
@@ -333,6 +333,7 @@ def read(settings, importObjects=False, importDetails=True, importPhysics=False,
             progress_update(total, prog, "Sound")
 
     wm.progress_end()
+    bpyhelper.deselect_all()
     print('Finished loading map')
     bpyhelper.LOCK_UPDATE = False
     bpyhelper.scene_update()

--- a/import_owmdl.py
+++ b/import_owmdl.py
@@ -455,7 +455,8 @@ def readmdl(materials = None, rotate=True):
 
     if len(data.cloths) > 0:
         for cloth in data.cloths:
-            bpy.ops.object.select_all(action='DESELECT')
+            bpyhelper.deselect_all()
+            #bpy.ops.object.select_all(action='DESELECT')
             i = 0
             for clothSubmesh in cloth.meshes:
                 submesh = meshes[clothSubmesh.id]
@@ -477,7 +478,7 @@ def readmdl(materials = None, rotate=True):
             # bpy.ops.mesh.remove_doubles()
             # bpy.ops.object.editmode_toggle()
 
-    bpy.ops.object.select_all(action='DESELECT')
+    bpyhelper.deselect_all()
     select_all(rootObject)
 
     return (rootObject, armature, meshes, empties, data)


### PR DESCRIPTION
This includes a few changes to improve the import speed of maps, models and entities, although it's way more noticeable in maps, this PR being focused on that.

First is a tiny weeny thing to remove a `str.lower()` in bin_ops which for map imports ran millions of times and used up to a minute according to profiling. Second is a selection tracking function to avoid calling `bpy.ops.select_all()` thousands of times causing Blender to update the scene unnecessarily. Third, are some changes in `importEmpties` to avoid using `bpy.ops` causing unnecessary updates again; this apparently fixed an issue with empties in map entities having wrong positions. 

There are further optimizations to be made in `importArmature` but I noped straight out of that code, honestly.
Also, the selection tracking was not implemented in the effects importer, that's still using UI operators.

These were measured on a I7-4790k with Blender 2.92

| Map  | Old Import Time | New Import Time |
| ------------- | ------------- | ------------- |
| Menu Hanamura  | 00:39  | 00:24  |
| Menu King's Row  | 01:36 |  00:52 |
| Menu Blizz World (W)  | 01:50 |  00:56 |
| Black Forest  | 04:00 |  02:13 |
| Practice Range  | 07:35 | 04:26  |
| Ilios Well  | 10:41 |  05:15 |