### PR TITLE
Further speed improvements ¯\_(ツ)_/¯

### DIFF
--- a/import_owmap.py
+++ b/import_owmap.py
@@ -26,7 +26,7 @@ def copy(obj, parent):
     if obj is None: return None
     new_obj = obj.copy()
     if obj.data is not None:
-        new_obj.data == obj.data.copy()
+        new_obj.data = obj.data.copy()
     new_obj.parent = parent
     bpyhelper.scene_link(new_obj)
     for child in obj.children:

--- a/import_owmap.py
+++ b/import_owmap.py
@@ -22,13 +22,15 @@ def pos_matrix(pos):
     return mtx.to_translation()
 
 
+link_queue = []
+
 def copy(obj, parent):
     if obj is None: return None
     new_obj = obj.copy()
     if obj.data is not None:
         new_obj.data = obj.data.copy()
     new_obj.parent = parent
-    bpyhelper.scene_link(new_obj)
+    link_queue.append(new_obj)
     for child in obj.children:
         copy(child, new_obj)
     return new_obj
@@ -97,7 +99,7 @@ def import_mat(path, prefix):
 
 
 def read(settings, importObjects=False, importDetails=True, importPhysics=False, light_settings=owm_types.OWLightSettings(), removeCollision=True, importSound=True):
-    global sets
+    global sets, link_queue
     bpyhelper.LOCK_UPDATE = True
     sets = settings
 
@@ -272,6 +274,10 @@ def read(settings, importObjects=False, importDetails=True, importPhysics=False,
             prog += 1
             remove(objCache[ob])
             progress_update(total, prog, ob)
+
+    for obj in link_queue:
+        bpyhelper.scene_link(obj)
+    link_queue = []
 
     LIGHT_MAP = ['SUN', 'SPOT', 'POINT']
 


### PR DESCRIPTION
I didn't expect this to happen, otherwise it would have been only one PR. I accidentally bypassed the performance black hole of `importArmature` by only linking cloned objects to the scene \*after\* all entities are imported, the original intention was to get a speedup from batching scene linking (which did go from 60 to 33 seconds in KR). Oh and this fixes the broken mesh cloning.

Updated import timings:

| Map  | 2.2.3 | 2.2.4 | This |
| ------------- | ------------- | ------------- | ------------- |
| Menu Hanamura  | 00:39  | 00:24  | 00:17  |
| Menu King's Row  | 01:36 |  00:52 | 00:38  |
| Menu Blizz World (W)  | 01:50 |  00:56 | 00:36  |
| Black Forest  | 04:00 |  02:13 | 01:32  |
| Practice Range  | 07:35 | 04:26  | 02:51  |
| Ilios Well  | 10:41 |  05:15 | 03:13  |
| King's Row  | 26:36 |  14:13 | 07:18  |
| Busan  | 01:05:30 |  33:55 | 24:40  |

~~importer go brr~~