### PR TITLE
A bit of brrr in model parsing [3/3]

### DIFF
--- a/bin_ops.py
+++ b/bin_ops.py
@@ -72,3 +72,18 @@ def readFmtFlat(file, fmts):
     if len(a) == 1:
         return a[0]
     return a
+
+def readFmtFlatArray(file, fmt, count):
+    size = 0
+    for char in fmt:
+        if char is '<': continue
+        if char in fmtSz:
+            size += fmtSz[char]
+        else:
+            print('unrecognized fmt char %s' % (char))
+    size*=count
+    if fmt[0] is '<': 
+        fmt="<"+(fmt[1:]*count)
+    else:
+        fmt*=count
+    return list(struct.unpack(fmt, file.read(size)))

--- a/read_owmdl.py
+++ b/read_owmdl.py
@@ -26,6 +26,7 @@ def read(filename):
     meshes = []
     for i in range(meshCount):
         name, materialKey, uvCount, vertexCount, indexCount = bin_ops.readFmtFlat(stream, owm_types.OWMDLMesh.structFormat)
+
         verts = []
         for j in range(vertexCount):
             position, normal = bin_ops.readFmt(stream, owm_types.OWMDLVertex.structFormat)
@@ -37,10 +38,9 @@ def read(filename):
             boneIndices = []
             boneWeights = []
             if boneDataCount > 0:
-                for k in range(boneDataCount):
-                    boneIndices += [bin_ops.readFmtFlat(stream, owm_types.OWMDLVertex.exFormat[2])]
-                for k in range(boneDataCount):
-                    boneWeights += [bin_ops.readFmtFlat(stream, owm_types.OWMDLVertex.exFormat[3])]
+                boneIndices += bin_ops.readFmtFlatArray(stream, owm_types.OWMDLVertex.exFormat[2],boneDataCount)
+                boneWeights += bin_ops.readFmtFlatArray(stream, owm_types.OWMDLVertex.exFormat[3],boneDataCount)
+
             col1 = []
             col2 = []
 
@@ -50,11 +50,11 @@ def read(filename):
 
             verts += [owm_types.OWMDLVertex(position, normal, uvs, boneDataCount, boneIndices, boneWeights, col1, col2)]
         faces = []
+
         for j in range(indexCount):
             pointCount = bin_ops.readFmt(stream, owm_types.OWMDLIndex.structFormat)[0]
             points = []
-            for k in range(pointCount):
-                points += [bin_ops.readFmtFlat(stream, owm_types.OWMDLIndex.exFormat[0])]
+            points += bin_ops.readFmtFlatArray(stream, owm_types.OWMDLIndex.exFormat[0],pointCount)
             faces += [owm_types.OWMDLIndex(pointCount, points)]
         meshes += [owm_types.OWMDLMesh(name, materialKey, uvCount, vertexCount, indexCount, verts, faces)]
 


### PR DESCRIPTION
I do not possess the brain power to rewrite this but this makes it a bit faster. Note it'd be better to avoid reading value by value since struct is better when reading larger chunks. No fancy table this time but quick testing of all 3 changes shaved off a minute on Practice Range (02:51 > 01:53) and a minute and a half on King's Row (07:18 > 05:41). The biggest hogs are this parser, and Blender being slow with shader nodes.
