### PR TITLE
Only update texture label fied

### DIFF
--- a/import_owmat.py
+++ b/import_owmat.py
@@ -173,7 +173,7 @@ def process_material(material, prefix, root, t):
             bfTyp = tm['Mapping'][tt[typ]]
             # print('[import_owmat]: {} is {}'.format(os.path.basename(texData[0]), tt[typ]))
             nodeTex.label = str(tt[typ])
-            nodeTex.name = str(tt[typ])
+            #nodeTex.name = str(tt[typ]) causes a chain of internal changes we dont want
             for colorSocketPoint in bfTyp[0]:
                 nodeSocketName = colorSocketPoint
                 if colorSocketPoint in tm['Alias']:


### PR DESCRIPTION
.name triggers collision checks and probably a whole bunch of internal updates that boggled this down. idk why this thing is still SO slow though I can't stare at it anymore. I give up. that brought it down from 40 to 25s in practice range but _I think_ 25s is still too much. Maybe I'll look into binops again later