### PR TITLE
Optionally link objects on map import

### DIFF
--- a/import_owmap.py
+++ b/import_owmap.py
@@ -1,14 +1,13 @@
+import math
 import os
 
-from . import read_owmap
-from . import import_owmdl
-from . import import_owmat
-from . import import_owentity
-from . import bpyhelper
-from . import owm_types
+import bpy
+import bpy_extras
+import mathutils
 from mathutils import *
-import math
-import bpy, bpy_extras, mathutils
+
+from . import (bpyhelper, import_owentity, import_owmat, import_owmdl,
+               owm_types, read_owmap)
 
 sets = None
 

--- a/manager.py
+++ b/manager.py
@@ -1,16 +1,14 @@
-from . import import_owmap
-from . import import_owentity
-from . import import_owmdl
-from . import import_owmat
-from . import import_oweffect
-from . import owm_types
-from . import bpyhelper
-import bpy
-from bpy.props import StringProperty, BoolProperty, FloatProperty, IntProperty, CollectionProperty
-from bpy_extras.io_utils import ImportHelper
-from bpy.app.handlers import persistent
-from bpy.utils import smpte_from_seconds
 from datetime import datetime
+
+import bpy
+from bpy.app.handlers import persistent
+from bpy.props import (BoolProperty, CollectionProperty, FloatProperty,
+                       IntProperty, StringProperty)
+from bpy.utils import smpte_from_seconds
+from bpy_extras.io_utils import ImportHelper
+
+from . import (bpyhelper, import_oweffect, import_owentity, import_owmap,
+               import_owmat, import_owmdl, owm_types)
 
 
 class ImportOWMDL(bpy.types.Operator, ImportHelper):

--- a/manager.py
+++ b/manager.py
@@ -805,7 +805,7 @@ class OWMCleanupTexOp(bpy.types.Operator):
 
 
 class OWMInternalSettings(bpy.types.PropertyGroup):
-    b_logsalot : bpy.props.BoolProperty(name="Log alot", description="Verbose logging", 
+    b_logsalot : bpy.props.BoolProperty(name="Log alot", description="Verbose logging",
         default=False, update=lambda self, context: self.update_logs_alot(context))
 
     def update_logs_alot(self, context):

--- a/manager.py
+++ b/manager.py
@@ -326,6 +326,12 @@ class ImportOWMAP(bpy.types.Operator, ImportHelper):
         default=False,
     )
 
+    link_objects : BoolProperty(
+        name='Link Objects',
+        description='Link objects instead of copying them',
+        default=False,
+    )
+
     def menu_func(self, context):
         self.layout.operator_context = 'INVOKE_DEFAULT'
         self.layout.operator(
@@ -361,7 +367,7 @@ class ImportOWMAP(bpy.types.Operator, ImportHelper):
         t = datetime.now()
         bpyhelper.LOCK_UPDATE = False
         try:
-            import_owmap.read(settings, self.importObjects, self.importDetails, self.importPhysics, light_settings, self.importRemoveCollision, self.importSounds)
+            import_owmap.read(settings, self.importObjects, self.importDetails, self.importPhysics, light_settings, self.importRemoveCollision, self.importSounds, self.link_objects)
         except KeyboardInterrupt:
             bpyhelper.LOCK_UPDATE = False
         import_owmat.cleanup()
@@ -386,6 +392,7 @@ class ImportOWMAP(bpy.types.Operator, ImportHelper):
         col = layout.column(align=True)
         col.label(text = 'Map')
         col.prop(self, 'importObjects')
+        col.prop(self, 'link_objects')
         col.prop(self, 'importDetails')
         col.prop(self, 'importSounds')
 


### PR DESCRIPTION
I got inspired by the Busan under a minute™ initiative. Maybe this helps.

before:
![image](https://user-images.githubusercontent.com/1469579/188286302-359d0b78-3da9-4824-9644-0a65f2b973f2.png)
```
>>> len(bpy.data.meshes)
14018
```

after:
![image](https://user-images.githubusercontent.com/1469579/188286307-1ae9dc4b-c51c-42d1-9c9f-e0d479186dbf.png)

```
>>> len(bpy.data.meshes)
1839
```

didnt test but shader view looks the same