### PR TITLE
update texture path handling to use PathUtil for consistency between platforms

### DIFF
--- a/importer/blender/BLMaterial.py
+++ b/importer/blender/BLMaterial.py
@@ -43,7 +43,7 @@ class BlenderMaterialTree:
                         continue
                     self.materials.setdefault(material.GUID, material)
                     for texture in material.textures:
-                        self.texPaths.setdefault(texture.GUID, texture.filepath)
+                        self.texPaths.setdefault(texture.GUID, PathUtil.joinPath(material.filepath, "..", texture.filepath))
 
                     modelLookData.materials[key] = material.GUID
 


### PR DESCRIPTION
For some reason textures are not found in blender on Linux (could be a special case but I saw a similar problem on the discord), their path being relative, hence this fixes it by adopting materials' file path.
Needs testing on windows too to ensure that it does not mess up the files there.